### PR TITLE
Add sample data seeding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ cd api
 npm install
 cp .env.example .env
 # Fill in MONGODB_URI and JWT_SECRET
+npm run seed   # optional: load sample data
 npm start
 ```
 

--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js",
-    "dev": "clear; nodemon server.js"
+    "dev": "clear; nodemon server.js",
+    "seed": "node sampleData.js"
   },
   "keywords": [],
   "author": "",

--- a/api/sampleData.js
+++ b/api/sampleData.js
@@ -1,0 +1,52 @@
+const mongoose = require('mongoose');
+const bcrypt = require('bcryptjs');
+const dotenv = require('dotenv');
+
+const User = require('./models/User');
+const Budget = require('./models/Budget');
+const Expense = require('./models/Expense');
+const Goal = require('./models/Goal');
+
+dotenv.config();
+
+async function seed() {
+  await mongoose.connect(process.env.MONGODB_URI);
+
+  await User.deleteMany({});
+  await Budget.deleteMany({});
+  await Expense.deleteMany({});
+  await Goal.deleteMany({});
+
+  const password = await bcrypt.hash('password123', 10);
+  const user = await User.create({
+    name: 'Test User',
+    email: 'test@example.com',
+    password
+  });
+
+  const budgets = [
+    { user_id: user._id, amount: 1000, month: '2024-01', auto_reset: true },
+    { user_id: user._id, amount: 1200, month: '2024-02', auto_reset: true }
+  ];
+
+  const expenses = [
+    { user_id: user._id, amount: 50, category: 'Food', note: 'Groceries', date: new Date('2024-01-05') },
+    { user_id: user._id, amount: 30, category: 'Transport', note: 'Bus pass', date: new Date('2024-01-07') }
+  ];
+
+  const goals = [
+    { user_id: user._id, title: 'New Laptop', target_amount: 1500, saved_amount: 100 }
+  ];
+
+  await Budget.insertMany(budgets);
+  await Expense.insertMany(expenses);
+  await Goal.insertMany(goals);
+
+  console.log('Sample data inserted');
+  await mongoose.disconnect();
+}
+
+seed().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `api/sampleData.js` with example user/budget/expense/goal records
- expose `npm run seed` to easily populate the database
- document seeding step in README

## Testing
- `pytest tests/test_forecast.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm test` *(fails: "Error: no test specified")*


------
https://chatgpt.com/codex/tasks/task_e_684c1f30a80c832cb7acb67cea28b0f0